### PR TITLE
Add formula for gr-iio

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-10.15 ]
+        package: [ libiio, libad9361-iio, gr-iio, iio-oscilloscope ]
 
     runs-on: ${{ matrix.os }}
 
@@ -16,11 +17,8 @@ jobs:
     - name: Copy formulae
       run: cp *.rb $(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/
     - name: Install
-      # We install the IIO Oscilloscope package, which builds the others
-      # through dependency resolution.
-      run: brew install --verbose --build-from-source iio-oscilloscope
-    - name: Test
       run: |
-        for formula in *.rb; do
-          brew test "${formula%.rb}"
-        done
+        [ "${{ matrix.package }}" = "gr-iio" ] && OPTIONS="--HEAD"
+        brew install --verbose --build-from-source $OPTIONS ${{ matrix.package }}
+    - name: Test
+      run: brew test ${{ matrix.package }}

--- a/gr-iio.rb
+++ b/gr-iio.rb
@@ -1,0 +1,74 @@
+class GrIio < Formula
+  include Language::Python::Virtualenv
+
+  desc "IIO blocks for GNU Radio"
+  homepage "https://wiki.analog.com/resources/tools-software/linux-software/gnuradio"
+  license "GPL-3.0"
+  head "https://github.com/analogdevicesinc/gr-iio.git", branch: "upgrade-3.8"
+
+  depends_on "bison" => :build
+  depends_on "cmake" => :build
+  depends_on "flex" => :build
+  depends_on "pkg-config" => :build
+  depends_on "swig" => :build
+
+  depends_on "boost"
+  depends_on "fftw"
+  depends_on "gmp"
+  depends_on "gnuradio"
+  depends_on "libad9361-iio"
+  depends_on "libiio"
+  depends_on "log4cpp"
+  depends_on "orc"
+  depends_on "python@3.9"
+  depends_on "volk"
+
+  # CMake does not detect this dependency correctly
+  depends_on "mpir" => :optional
+
+  # This patch has not yet made it into the GNU Radio 3.8-compatible branch
+  # https://github.com/analogdevicesinc/gr-iio/pull/90
+  patch do
+    url "https://github.com/analogdevicesinc/gr-iio/commit/c35a071cb006d5bf1a0416422113b9a45ec96daa.patch?full_index=1"
+    sha256 "1004ada83fac0813076b881eabfa5aaaf703a090076c4b69400f0addcfdac1f8"
+  end
+
+  def install
+    # Create a Python virtual environment into which we install our module
+    # https://docs.brew.sh/Python-for-Formula-Authors
+    venv_root = libexec/"venv"
+    xy = Language::Python.major_minor_version "python3"
+    ENV.prepend_create_path "PYTHONPATH", "#{venv_root}/lib/python#{xy}/site-packages"
+    virtualenv_create(venv_root, "python3")
+
+    mkdir "build" do
+      cmake_args = [
+        "-DPYTHON_EXECUTABLE=#{venv_root}/bin/python",
+      ]
+      system "cmake", "..", *cmake_args, *std_cmake_args
+      system "make"
+      system "make", "install"
+    end
+
+    # Leave a pointer to our Python module directory where GNU Radio can find it
+    site_packages = lib/"python#{xy}/site-packages"
+    pth_contents = "#{site_packages}\n"
+    (etc/"gnuradio/plugins.d/gr-iio.pth").write pth_contents
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <iio/math.h>
+      int main() {
+        gr::iio::iio_math::make("0");
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-std=c++11", "-L#{lib}", "-lgnuradio-iio", "-o", "test", "test.cpp"
+    system "./test"
+
+    # Make sure GNU Radio's Python can find our module
+    (testpath/"testimport.py").write "import iio\n"
+    system Formula["gnuradio"].libexec/"venv/bin/python", testpath/"testimport.py"
+  end
+end


### PR DESCRIPTION
This is a formula to install `gr-iio`.

It requires this change to Homebrew for the `gnuradio` formula: https://github.com/Homebrew/homebrew-core/pull/65437

The formula is `HEAD`-only because there is no release that builds with GNU Radio 3.8, which is what Homebrew offers. There is a patch needed to fix a compilation error that I cherry-pick from `master` because it has not yet landed in `upgrade-3.8` yet.

Normally, a Homebrew formula should declares all of its Python package dependencies as `resource` sections to be installed by `pip`, as the mainline `gr-osmosdr` formula does. However it doesn't look to me like there are any.

There are two minor issues with the dependencies:

1. [This wiki page](https://wiki.analog.com/resources/tools-software/linux-software/gnuradio#gnu_radio_38) says that building it requires `liborc-dev` on Linux, so I added the `orc` dependency as well, but I can't figure out if it is actually used?

2. CMake seems to fail to detect MPIR but we build successfully anyway, so I marked it optional. This is something that probably needs to be fixed in `gr-iio`'s CMake configuration. (This needs to be resolved before upstreaming this to `homebrew-core`.)